### PR TITLE
Fix Integrated Dynamics facades cannot be crafted

### DIFF
--- a/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/appliedenergistics2/removal.js
+++ b/kubejs/server_scripts/enigmatica/kubejs/expert/recipetypes/appliedenergistics2/removal.js
@@ -7,7 +7,7 @@ onEvent('recipes', (event) => {
     //Disable an item completely.
     itemsToRemoveAE.forEach((entry) => {
         event.remove({ output: entry });
-        event.remove({ input: entry });
+        event.remove({ input: entry, id: '/appliedenergistics2/' });
     });
 
     //Remove a recipe by id


### PR DESCRIPTION
## Reproduction Steps
1. Place **Facade - None** and **Stone** into the crafting table.

## Expected Behavior
- **Facade - Stone** is crafted.

## Actual Behavior
- No item can be crafted.

## Explanation of PR Content
The recipe for facades with various items is the same recipe, including those that have been removed. Removing this recipe causes all facade crafting recipes to be deleted.
This PR restricts the removed recipe to the AE2 scope. Other possible solutions include excluding recipes from ID.
